### PR TITLE
standardize on one Identity

### DIFF
--- a/src/Data/Vinyl/Reflect.hs
+++ b/src/Data/Vinyl/Reflect.hs
@@ -3,7 +3,7 @@
 -- | Reflection utilities for vinyl records.
 module Data.Vinyl.Reflect where
 import Data.Foldable (Foldable, foldMap)
-import Data.Functor.Identity
+import Data.Vinyl.Idiom.Identity
 import Data.Monoid (Sum(..))
 import Data.Vinyl (Rec, PlainRec, (:::))
 import Foreign.Storable (Storable(sizeOf))

--- a/src/Graphics/VinylGL/Uniforms.hs
+++ b/src/Graphics/VinylGL/Uniforms.hs
@@ -10,7 +10,7 @@ module Graphics.VinylGL.Uniforms (setAllUniforms, setSomeUniforms, setUniforms,
                                   HasFieldGLTypes(..), SetUniformFields) where
 import Control.Applicative ((<$>))
 import Data.Foldable (traverse_)
-import Data.Functor.Identity
+import Data.Vinyl.Idiom.Identity
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S


### PR DESCRIPTION
vinyl-gl currently doesn't build on ghc-7.8, due to inconsistent use of Data.Functor.Identity and Data.Vinyl.Idiom.Identity.  Since `PlainRec` uses the vinyl variant, it seems sensible to standardize on that definition (at least for now).
